### PR TITLE
NetworkPkg/IScsiDxe: don't call IScsiPublishIbft() from IScsiStop()

### DIFF
--- a/NetworkPkg/IScsiDxe/IScsiDriver.c
+++ b/NetworkPkg/IScsiDxe/IScsiDriver.c
@@ -1165,10 +1165,7 @@ IScsiStop (
   //
   IScsiRemoveNic (IScsiController);
 
-  //
-  // Update the iSCSI Boot Firmware Table.
-  //
-  IScsiPublishIbft ();
+  // DO NOT update the iSCSI Boot Firmware Table here.
 
   if (Private->Session != NULL) {
     IScsiSessionAbort (Private->Session);


### PR DESCRIPTION
Calling IScsiPublishIbft() from IScsiStop() effectively removes the iBFT ACPI table, even after successful attempts, and even if boot from iSCSI is selected in the boot menu.

Don't update the table in IScsiStop().