### PR TITLE
GitHub workflows: improve "release" logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,9 +71,13 @@ jobs:
 
   release:
     if: |
-          ( github.ref == 'refs/heads/timberland_1.0_final' &&
-            github.event_name == 'push' ) ||
-          github.event_name == 'workflow_dispatch'
+      ( github.ref ==
+        format('refs/heads/{0}', github.event.repository.default_branch) &&
+        ( github.event_name == 'push' ||
+          ( github.event_name == 'pull_request' &&
+            github.event.action == 'closed' &&
+            github.event.pull_request.merged == true ) ) ) ||
+      github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Run the "release" part of the workflow if and only if

- the event was manually triggered (workflow_dispatch), OR
- it's a push or a pull request merge in the configured default branch of the repository
